### PR TITLE
Drop long arrays from the logs to save space

### DIFF
--- a/lib/sidekiq/middleware/server/logging.rb
+++ b/lib/sidekiq/middleware/server/logging.rb
@@ -7,7 +7,7 @@ module Sidekiq
           Sidekiq::Logging.with_context(log_context(worker, item)) do
             begin
               start = Time.now
-              logger.info { "#{Thread.current.object_id.to_s(36)} started: #{Sidekiq.dump_json(item)}" }
+              logger.info { "#{Thread.current.object_id.to_s(36)} started: #{printable_item(item)}" }
               yield
               logger.info { "#{Thread.current.object_id.to_s(36)} processed: #{item['jid']} took #{elapsed(start)} sec" }
             rescue Exception
@@ -24,6 +24,20 @@ module Sidekiq
         def log_context(worker, item)
           klass = item['wrapped'.freeze] || worker.class.to_s
           "#{klass} JID-#{item['jid'.freeze]}#{" BID-#{item['bid'.freeze]}" if item['bid'.freeze]}"
+        end
+
+        def printable_item(item)
+          item_to_print = item.dup
+
+          item_to_print['args'] = item_to_print['args'].map do |arg|
+            unless arg.is_a?(Array) && arg.count > 5
+              arg
+            else
+              "<Array of #{value.count} elements>"
+            end
+          end
+
+          Sidekiq.dump_json(item_to_print)
         end
 
         def elapsed(start)


### PR DESCRIPTION
Now arrays over 5 elements will show `<Array of X elements>` instead